### PR TITLE
Uws11 update

### DIFF
--- a/README.changes
+++ b/README.changes
@@ -1,3 +1,12 @@
+2016/03/22
+==========
+
+UWS update (branch uws11_update): new field 'creationTime' needed in Uws_Jobs table
+on the web server:
+
+ALTER TABLE `Uws_Jobs` ADD COLUMN `creationTime` VARCHAR(256) AFTER quote;
+
+
 2015/09/08
 ==========
 

--- a/library/Wordpress/theme/functions.php
+++ b/library/Wordpress/theme/functions.php
@@ -201,7 +201,7 @@ function daiquiri_video_meta_box($object, $box) {
     $post_id = $object->ID;
     $poster = get_post_meta($post_id,'video_poster',true);
     $mp4    = get_post_meta($post_id,'video_mp4',true);
-    $mp4    = get_post_meta($post_id,'video_avi',true);
+    $avi    = get_post_meta($post_id,'video_avi',true);
     $ogg    = get_post_meta($post_id,'video_ogg',true);
     $webm   = get_post_meta($post_id,'video_webm',true);
 

--- a/modules/query/models/Query.php
+++ b/modules/query/models/Query.php
@@ -111,15 +111,16 @@ class Query_Model_Query extends Daiquiri_Model_Abstract {
     }
 
     /**
-     * Querys the database with a plain text query.
+     * Queries the database with a plain text query.
      * @param string $sql the sql string
      * @param bool $plan flag for plan creation
      * @param string $table result table
      * @param array $options for further options that are handeled by the queue
+     * @param string $creationTime time of creation for uws-jobs (from pending phase) (for new UWS 1.1)
      * @param string $jobType job type of the new job
      * @return array $response
      */
-    public function query($sql, $plan = false, $table, $sources, $options = array(), $jobType = 'web') {
+    public function query($sql, $plan = false, $table, $sources, $options = array(), $creationTime = NULL, $jobType = 'web') {
         // init error array
         $errors = array();
 
@@ -182,6 +183,9 @@ class Query_Model_Query extends Daiquiri_Model_Abstract {
             $tmp[] = $this->_queue->quoteIdentifier($source['database'],$source['table']);
         }
         $job['sources'] = implode(',',$tmp);
+
+        // also provide the creationTime as option to submitJob
+        $options['creationTime'] = $creationTime;
 
         // submit job
         $this->_queue->submitJob($job, $errors, $options);

--- a/modules/query/models/Resource/DirectQuery.php
+++ b/modules/query/models/Resource/DirectQuery.php
@@ -163,7 +163,7 @@ class Query_Model_Resource_DirectQuery extends Query_Model_Resource_AbstractQuer
         }
         // check if time is 0, even if it was already set (because if creationTime was NULL, we do not want to use this)
         if ($job['time'] == false || $job['time'] == "0000-00-00 00:00:00" || $job['time'] == NULL) {
-            $job['time'] = date("Y-m-d\TH:i:s");
+            $job['time'] = date("Y-m-d H:i:s");
         }
 
         $job['complete'] = true;

--- a/modules/query/models/Resource/DirectQuery.php
+++ b/modules/query/models/Resource/DirectQuery.php
@@ -71,7 +71,7 @@ class Query_Model_Resource_DirectQuery extends Query_Model_Resource_AbstractQuer
 
         // get jobId from the options, or not
         if (!empty($options) && array_key_exists('jobId', $options)) {
-            $job['id'] = "{$options['jobId']}";
+            $job['id'] = "{$options['jobId']}"; // will be overwritten later on by "true" jobId => remove?
         }
 
         // create the actual sql statement
@@ -156,10 +156,19 @@ class Query_Model_Resource_DirectQuery extends Query_Model_Resource_AbstractQuer
         }
 
         // set other fields in job object
-        $job['time'] = date("Y-m-d\TH:i:s");
+
+        // if no time is set yet (or it is Null/0's), then create it now, otherwise keep the stored (creation) time
+        if (!empty($options) && array_key_exists('creationTime', $options)) {
+            $job['time'] = $options['creationTime'];
+        }
+        // check if time is 0, even if it was already set (because if creationTime was NULL, we do not want to use this)
+        if ($job['time'] == false || $job['time'] == "0000-00-00 00:00:00" || $job['time'] == NULL) {
+            $job['time'] = date("Y-m-d\TH:i:s");
+        }
+
         $job['complete'] = true;
 
-        // insert job into jobs table
+        // insert job into jobs table // is this the one on the server??
         $job['id'] = $this->getJobResource()->insertRow($job);
     }
 

--- a/modules/query/models/Resource/QQueueQuery.php
+++ b/modules/query/models/Resource/QQueueQuery.php
@@ -153,10 +153,19 @@ class Query_Model_Resource_QQueueQuery extends Query_Model_Resource_AbstractQuer
             return Query_Model_Resource_QQueueQuery::$_status['error'];
         }
 
-        // fetch the new jobs row for the timestamp and the status
+        // fetch the new jobs row for the status
         $row = $this->fetchRow($job['id']);
-        $job['time'] = $row['timeSubmit'];
         $job['status_id'] = $row['status_id'];
+
+        // if no time is set yet, then create it now, otherwise keep the stored (creation) time
+        // set the job's 'time' to the creationTime provided in $options;
+        // if no creationTime given (or Null/000), use "timeSubmit" from the server instead
+        if (!empty($options) && array_key_exists('creationTime', $options)) {
+            $job['time'] = $options['creationTime'];
+        }
+        if ($job['time'] == false || $job['time'] == "0000-00-00 00:00:00" || $job['time'] == NULL) {
+            $job['time'] = $row['timeSubmit'];
+        }
 
         // insert job into jobs table
         $this->getJobResource()->insertRow($job);

--- a/modules/query/models/Uws.php
+++ b/modules/query/models/Uws.php
@@ -232,10 +232,19 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
             }
         }
 
-        // copy jobs into jobs-object
+        // copy jobs into jobs-object, convert time format
+        // (This would be a good opportunity to convert to UTC time zone as well,
+        //  but currently this is not required by the standard.)
         $jobs = new Uws_Model_Resource_Jobs();
         foreach ($joblist as $job) {
-            $jobs->addJob($job['id'], $job['href'], array($job['status']), $job['creationTime'], $job['runId'], $job['ownerId']);
+            $creationdatetime = new DateTime($job['creationTime']);
+            $creationdatetime = $creationdatetime->format('c');
+            $jobs->addJob($job['id'],
+                          $job['href'],
+                          array($job['status']),
+                          $creationdatetime,
+                          $job['runId'],
+                          $job['ownerId']);
         }
 
         return $jobs;

--- a/modules/query/models/Uws.php
+++ b/modules/query/models/Uws.php
@@ -434,7 +434,7 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
             $resource->updateRow($job->jobId, array("phase" => "ERROR", "errorSummary" => Zend_Json::encode($job->errorSummary)));
 
             // job is in final state now, add startTime and endTime
-            $now = date('Y-m-d\TH:i:s');
+            $now = date('Y-m-d H:i:s');
             $resource->updateRow($job->jobId, array("startTime" => $now, "endTime" => $now));
 
             return;
@@ -473,7 +473,7 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
                 $resource->updateRow($job->jobId, array("phase" => "ERROR", "errorSummary" => Zend_Json::encode($job->errorSummary)));
 
                 // job is in final state now (ERROR), add startTime and endTime
-                $now = date('Y-m-d\TH:i:s');
+                $now = date('Y-m-d H:i:s');
                 $resource->updateRow($job->jobId, array("startTime" => $now, "endTime" => $now));
 
                 return;
@@ -485,7 +485,7 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
             $resource->updateRow($job->jobId, array("phase" => "ERROR", "errorSummary" => Zend_Json::encode($job->errorSummary)));
 
             // job is in final state now (ERROR), add startTime and endTime
-            $now = date('Y-m-d\TH:i:s');
+            $now = date('Y-m-d H:i:s');
             $resource->updateRow($job->jobId, array("startTime" => $now, "endTime" => $now));
 
             return;
@@ -515,7 +515,7 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
             $resource->updateRow($job->jobId, array("phase" => "ERROR", "errorSummary" => Zend_Json::encode($job->errorSummary)));
 
             // job is in final state now (ERROR), add startTime and endTime
-            $now = date('Y-m-d\TH:i:s');
+            $now = date('Y-m-d H:i:s');
             $resource->updateRow($job->jobId, array("startTime" => $now, "endTime" => $now));
 
             return;

--- a/modules/query/models/Uws.php
+++ b/modules/query/models/Uws.php
@@ -278,6 +278,12 @@ class Query_Model_Uws extends Uws_Model_UwsAbstract {
                 $datetimeEnd = new DateTime($row['timeFinish']);
                 $jobUWS->endTime = $datetimeEnd->format('c');
             }
+
+            if ($row['time'] != "0000-00-00 00:00:00") {
+                $datetimeCreation = new DateTime($row['time']);
+                $jobUWS->creationTime = $datetimeCreation->format('c');
+            }
+
         } else {
             // for simple queue
             $datetime = new DateTime($row['time']);

--- a/modules/uws/db/schema.sql
+++ b/modules/uws/db/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS Uws_Jobs (
   `ownerId` VARCHAR(256),
   `phase` VARCHAR(64) NOT NULL,
   `quote` DATETIME,
+  `creationTime` DATETIME,
   `startTime` DATETIME,
   `endTime` DATETIME,
   `executionDuration` BIGINT,

--- a/modules/uws/models/Resource/JobSummaryType.php
+++ b/modules/uws/models/Resource/JobSummaryType.php
@@ -36,6 +36,7 @@ class Uws_Model_Resource_JobSummaryType extends Uws_Model_Resource_Abstract {
         $this->ownerId = false;
         $this->phase = "PENDING";
         $this->quote = false;
+        $this->creationTime = false;
         $this->startTime = false;
         $this->endTime = false;
         $this->executionDuration = 0;
@@ -99,10 +100,11 @@ class Uws_Model_Resource_JobSummaryType extends Uws_Model_Resource_Abstract {
         $job->appendChild($version);
 
         $this->_writeXMLElement($xmlDoc, $job, "jobId");
-        $this->_writeXMLElement($xmlDoc, $job, "runId", true);
+        $this->_writeXMLElement($xmlDoc, $job, "runId"); //, true, do not add "true: in order to set the element even if null
         $this->_writeXMLElement($xmlDoc, $job, "ownerId");
         $this->_writeXMLElement($xmlDoc, $job, "phase");
         $this->_writeXMLElement($xmlDoc, $job, "quote");
+        $this->_writeXMLElement($xmlDoc, $job, "creationTime");
         $this->_writeXMLElement($xmlDoc, $job, "startTime");
         $this->_writeXMLElement($xmlDoc, $job, "endTime");
         $this->_writeXMLElement($xmlDoc, $job, "executionDuration");

--- a/modules/uws/models/Resource/Jobs.php
+++ b/modules/uws/models/Resource/Jobs.php
@@ -32,12 +32,17 @@ class Uws_Model_Resource_Jobs extends Uws_Model_Resource_Abstract {
         $this->jobref = array();
     }
 
-    public function addJob($id, $href, array $phases) {
+    public function addJob($id, $href, array $phases, $creationTime, $runId, $ownerId) {
         $newJob = new Uws_Model_Resource_ShortJobDescriptionType("jobref");
 
         $newJob->id = $id;
         $newJob->reference->href = $href;
         $newJob->phase = $phases;
+
+        // optional new keywords for updated UWS 1.1 version
+        $newJob->creationTime = $creationTime;
+        $newJob->runId = $runId;
+        $newJob->ownerId = $ownerId;
 
         $this->jobref[] = $newJob;
     }

--- a/modules/uws/models/Resource/ShortJobDescriptionType.php
+++ b/modules/uws/models/Resource/ShortJobDescriptionType.php
@@ -31,6 +31,10 @@ class Uws_Model_Resource_ShortJobDescriptionType extends Uws_Model_Resource_Abst
 
         $this->name = $name;
         $this->id = false;
+        $this->jobId = false;
+        $this->runId = false;
+        $this->ownerId = false;
+        $this->creationTime = false;
         $this->reference = new Uws_Model_Resource_ReferenceAttrGrp();
         $this->phase = array();
     }
@@ -38,9 +42,26 @@ class Uws_Model_Resource_ShortJobDescriptionType extends Uws_Model_Resource_Abst
     public function toXML(&$xmlDoc, &$node = false) {
         $job = $xmlDoc->createElementNS($this->nsUws, "uws:{$this->name}");
 
+        // note: this id must be the jobId for the job (not job name or resultTable name),
+        // This must be the same id as used in the href-element
         $id = $xmlDoc->createAttribute("id");
         $id->value = htmlspecialchars($this->id, ENT_QUOTES);
         $job->appendChild($id);
+
+        // add optional attributes allowed by UWS 1.1 update:
+        // use our job-name or table-name for runId
+        $runId = $xmlDoc->createAttribute("runId");
+        $runId->value = htmlspecialchars($this->runId, ENT_QUOTES);
+        $job->appendChild($runId);
+
+        $ownerId = $xmlDoc->createAttribute("ownerId");
+        $ownerId->value = htmlspecialchars($this->ownerId, ENT_QUOTES);
+        $job->appendChild($ownerId);
+
+        $creationTime = $xmlDoc->createAttribute("creationTime");
+        $creationTime->value = htmlspecialchars($this->creationTime, ENT_QUOTES);
+        $job->appendChild($creationTime);
+
         $this->reference->toXML($xmlDoc, $job);
 
         foreach ($this->phase as $phase) {

--- a/modules/uws/models/Resource/UWSJobs.php
+++ b/modules/uws/models/Resource/UWSJobs.php
@@ -104,6 +104,11 @@ class Uws_Model_Resource_UWSJobs extends Daiquiri_Model_Resource_Table {
             $jobUWS->endTime = $datetime->format('c');
         }
 
+        if ($row['creationTime'] !== "0000-00-00 00:00:00" && $row['creationTime'] != NULL) {
+            $datetime = new DateTime($row['creationTime']);
+            $jobUWS->creationTime = $datetime->format('c');
+        }
+
         $jobUWS->executionDuration = intval($row['executionDuration']);
 
         if ($row['destruction'] !== "0000-00-00 00:00:00" && $row['destruction'] != NULL) {

--- a/modules/uws/models/Resource/UWSJobs.php
+++ b/modules/uws/models/Resource/UWSJobs.php
@@ -92,6 +92,7 @@ class Uws_Model_Resource_UWSJobs extends Daiquiri_Model_Resource_Table {
         $jobUWS->ownerId = $row['ownerId'];
         $jobUWS->phase = $row['phase'];
         $jobUWS->quote = $row['quote'];
+        $jobUWS->creationTime = $row['creationTime'];
 
         if ($row['startTime'] !== "0000-00-00 00:00:00" && $row['startTime'] != NULL) {
             $datetime = new DateTime($row['startTime']);

--- a/modules/uws/models/UwsAbstract.php
+++ b/modules/uws/models/UwsAbstract.php
@@ -568,6 +568,10 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
 
         $jobUWS->quote = $this->getQuote();
 
+        // set a creation time, for updated UWS 1.1 version
+        $now = date('Y-m-d\TH:i:s');
+        $jobUWS->creationTime = $now;
+
         //no destruction time supported, so return hillariously high number
         $datetime = new DateTime('31 Dec 2999');
         $jobUWS->destruction = $datetime->format('c');
@@ -587,9 +591,13 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
             $jobUWS->executionDuration = NULL;
         }
 
+        // Do not support a custom runId set by client, because we want to use
+        // the table-name for this
         if (isset($postParams['runid'])) {
-            $jobUWS->runId = $postParams['runid'];
             unset($postParams['runid']);
+        }
+        if (isset($postParams['table'])) {
+            $jobUWS->runId = $postParams['table'];
         } else {
             $jobUWS->runId = NULL;
         }
@@ -606,6 +614,7 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
         $job['ownerId'] = $jobUWS->ownerId;
         $job['phase'] = $jobUWS->phase;
         $job['quote'] = $jobUWS->quote;
+        $job['creationTime'] = $jobUWS->creationTime;
         $job['startTime'] = $jobUWS->startTime;
         $job['endTime'] = $jobUWS->endTime;
         $job['executionDuration'] = $jobUWS->executionDuration;

--- a/modules/uws/models/UwsAbstract.php
+++ b/modules/uws/models/UwsAbstract.php
@@ -569,7 +569,8 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
         $jobUWS->quote = $this->getQuote();
 
         // set a creation time, for updated UWS 1.1 version
-        $now = date('Y-m-d\TH:i:s');
+        $now = date('Y-m-d H:i:s');
+        //$now = $now->format('c');
         $jobUWS->creationTime = $now;
 
         //no destruction time supported, so return hillariously high number
@@ -671,7 +672,7 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
 
             // job is put into final state; set endTime, if not existing yet
             if (!$job->endTime) {
-                $datetimeEnd = date('Y-m-d\TH:i:s');
+                $datetimeEnd = date('Y-m-d H:i:s');
                 $job->endTime = $datetimeEnd;
                 $resource->updateRow($job->jobId, array("endTime" => $job->endTime));
             }

--- a/modules/uws/models/UwsAbstract.php
+++ b/modules/uws/models/UwsAbstract.php
@@ -639,7 +639,7 @@ abstract class Uws_Model_UwsAbstract extends Daiquiri_Model_Abstract {
         return $jobId;
     }
 
-    //optains a (pending) job in the UWS job list
+    //obtains a (pending) job from the UWS job list
     public function getPendingJob($id) {
         $resource = new Uws_Model_Resource_UWSJobs();
         $job = $resource->fetchObjectWithId($id);


### PR DESCRIPTION
Adjust to latest updates of UWS 1.1, mainly using creationTime for sorting and printing additional attributes ownerId, runId and creationTime in joblist.
Latest UWS draft is from Feb. 25, not yet updated (but soon) on http://www.ivoa.net/documents/UWS/
(latest version is on volute at the moment).
